### PR TITLE
Strip inline test code from Rust files before estimation

### DIFF
--- a/src/languages/cairoAdapter.ts
+++ b/src/languages/cairoAdapter.ts
@@ -1,4 +1,4 @@
-import { FileContent, SupportedLanguage, GraphNode, GraphEdge, Visibility } from "../engine/types.js";
+import { FileContent, SupportedLanguage, GraphNode, GraphEdge, Visibility, FileMetrics, DiffFileMetrics } from "../engine/types.js";
 import { BaseAdapter } from "./baseAdapter.js";
 import { TreeSitterService } from "../util/treeSitter.js";
 import { Query, Node } from "web-tree-sitter";
@@ -15,7 +15,27 @@ export class CairoAdapter extends BaseAdapter {
         SIMPLE_CALL: `(call_expression function: (identifier) @FUNC)`,
         SCOPED_CALL: `(call_expression (scoped_identifier) @FUNC)`,
         // Method calls: self.method() → field_expression with field_identifier
-        METHOD_CALL: `(call_expression (field_expression (field_identifier) @FUNC))`
+        METHOD_CALL: `(call_expression (field_expression (field_identifier) @FUNC))`,
+        TEST_ATTR: `
+            (attribute_item
+                (attribute
+                    (identifier) @attr-name
+                    (#eq? @attr-name "test")
+                )
+            ) @test-attr
+        `,
+        CFG_TEST_ATTR: `
+            (attribute_item
+                (attribute
+                    (identifier) @outer
+                    arguments: (token_tree
+                        (identifier) @inner
+                    )
+                    (#eq? @outer "cfg")
+                    (#eq? @inner "test")
+                )
+            ) @cfg-test-attr
+        `
     } as const;
 
     private symbolsByContainer: Map<string, GraphNode[]> = new Map();
@@ -276,6 +296,165 @@ export class CairoAdapter extends BaseAdapter {
         if (free) return free;
 
         return this.symbolsByLabel.get(callText)?.[0];
+    }
+
+    /**
+     * Strips test code from Cairo source content.
+     * Removes: #[cfg(test)] module blocks and standalone #[test] functions.
+     * Cairo's test syntax mirrors Rust exactly.
+     */
+    async stripTestCode(content: string): Promise<string> {
+        const service = TreeSitterService.getInstance();
+        const lang = await service.getLanguage(SupportedLanguage.Cairo);
+        const parser = await service.createParser(SupportedLanguage.Cairo);
+
+        const tree = parser.parse(content);
+        if (!tree) return content;
+
+        const rangesToRemove: Array<{ start: number; end: number }> = [];
+
+        const cfgTestQuery = new Query(lang, CairoAdapter.QUERIES.CFG_TEST_ATTR);
+        const cfgTestAttrs = new Set(
+            cfgTestQuery.matches(tree.rootNode)
+                .map(m => m.captures.find(c => c.name === 'cfg-test-attr')!.node.id)
+        );
+
+        const testAttrQuery = new Query(lang, CairoAdapter.QUERIES.TEST_ATTR);
+        const testAttrs = new Set(
+            testAttrQuery.matches(tree.rootNode)
+                .map(m => m.captures.find(c => c.name === 'test-attr')!.node.id)
+        );
+
+        // 1. Find #[cfg(test)] mod blocks
+        const modQuery = new Query(lang, '(mod_item) @mod');
+        const modCaptures = modQuery.captures(tree.rootNode);
+
+        for (const capture of modCaptures) {
+            if (this.hasAttributeFromSet(capture.node, cfgTestAttrs)) {
+                const attrStart = this.getAttributeStart(capture.node);
+                rangesToRemove.push({
+                    start: attrStart,
+                    end: capture.node.endIndex
+                });
+            }
+        }
+
+        // 2. Find standalone #[test] functions
+        const fnQuery = new Query(lang, '(function_item) @fn');
+        const fnCaptures = fnQuery.captures(tree.rootNode);
+
+        for (const capture of fnCaptures) {
+            if (this.hasAttributeFromSet(capture.node, testAttrs)) {
+                const alreadyCovered = rangesToRemove.some(
+                    r => capture.node.startIndex >= r.start && capture.node.endIndex <= r.end
+                );
+                if (!alreadyCovered) {
+                    const attrStart = this.getAttributeStart(capture.node);
+                    rangesToRemove.push({
+                        start: attrStart,
+                        end: capture.node.endIndex
+                    });
+                }
+            }
+        }
+
+        if (rangesToRemove.length === 0) return content;
+
+        rangesToRemove.sort((a, b) => b.start - a.start);
+
+        let result = content;
+        for (const range of rangesToRemove) {
+            let end = range.end;
+            if (end < result.length && result[end] === '\n') end++;
+            result = result.substring(0, range.start) + result.substring(end);
+        }
+
+        return result;
+    }
+
+    private hasAttributeFromSet(node: Node, attrIds: Set<number>): boolean {
+        // Cairo: attributes are sibling attribute_item nodes preceding the item
+        let prev = node.previousNamedSibling;
+        while (prev && prev.type === 'attribute_item') {
+            if (attrIds.has(prev.id)) return true;
+            prev = prev.previousNamedSibling;
+        }
+        return false;
+    }
+
+    private getAttributeStart(node: Node): number {
+        let start = node.startIndex;
+        let prev = node.previousNamedSibling;
+        while (prev && prev.type === 'attribute_item') {
+            start = prev.startIndex;
+            prev = prev.previousNamedSibling;
+        }
+        return start;
+    }
+
+    override async calculateMetrics(files: FileContent[]): Promise<FileMetrics[]> {
+        const strippedFiles = await Promise.all(
+            files.map(async (file) => ({
+                path: file.path,
+                content: await this.stripTestCode(file.content)
+            }))
+        );
+        return super.calculateMetrics(strippedFiles);
+    }
+
+    override async calculateDiffMetrics(
+        file: FileContent,
+        addedLines: number[],
+        removedLines: number[],
+        status: 'added' | 'modified' | 'deleted'
+    ): Promise<DiffFileMetrics> {
+        if (status === 'deleted') {
+            return super.calculateDiffMetrics(file, addedLines, removedLines, status);
+        }
+
+        const strippedContent = await this.stripTestCode(file.content);
+        const originalLines = file.content.split('\n');
+        const strippedLines = strippedContent.split('\n');
+
+        const removedOriginalLines = new Set<number>();
+        let oi = 0, si = 0;
+        while (oi < originalLines.length && si < strippedLines.length) {
+            if (originalLines[oi] === strippedLines[si]) {
+                oi++;
+                si++;
+            } else {
+                removedOriginalLines.add(oi + 1);
+                oi++;
+            }
+        }
+        while (oi < originalLines.length) {
+            removedOriginalLines.add(oi + 1);
+            oi++;
+        }
+
+        const lineMapping = new Map<number, number>();
+        let strippedLineNum = 1;
+        for (let origLine = 1; origLine <= originalLines.length; origLine++) {
+            if (!removedOriginalLines.has(origLine)) {
+                lineMapping.set(origLine, strippedLineNum);
+                strippedLineNum++;
+            }
+        }
+
+        const filteredAddedLines: number[] = [];
+        for (const lineNum of addedLines) {
+            const mappedLine = lineMapping.get(lineNum);
+            if (mappedLine !== undefined) {
+                filteredAddedLines.push(mappedLine);
+            }
+        }
+
+        return super.calculateDiffMetrics(
+            { path: file.path, content: strippedContent },
+            filteredAddedLines,
+            removedLines,
+            status
+        );
     }
 
 }

--- a/src/languages/moveAdapter.ts
+++ b/src/languages/moveAdapter.ts
@@ -1,4 +1,4 @@
-import { FileContent, SupportedLanguage, GraphNode, GraphEdge, Visibility } from "../engine/types.js";
+import { FileContent, SupportedLanguage, GraphNode, GraphEdge, Visibility, FileMetrics, DiffFileMetrics } from "../engine/types.js";
 import { BaseAdapter } from "./baseAdapter.js";
 import { TreeSitterService } from "../util/treeSitter.js";
 import { Query, Node } from "web-tree-sitter";
@@ -8,7 +8,23 @@ export class MoveAdapter extends BaseAdapter {
     private static readonly QUERIES = {
         MODULES: `(module) @module`,
         FUNCTIONS: `(function_decl) @function`,
-        CALLS: `(call_expr) @call`
+        CALLS: `(call_expr) @call`,
+        TEST_ATTR: `
+            (attributes
+                (attribute
+                    (identifier) @attr-name
+                    (#eq? @attr-name "test")
+                )
+            ) @test-attrs
+        `,
+        TEST_ONLY_ATTR: `
+            (attributes
+                (attribute
+                    (identifier) @attr-name
+                    (#eq? @attr-name "test_only")
+                )
+            ) @test-only-attrs
+        `
     } as const;
 
     private symbolsByModule: Map<string, GraphNode[]> = new Map();
@@ -227,6 +243,153 @@ export class MoveAdapter extends BaseAdapter {
         if (free) return free;
 
         return this.symbolsByLabel.get(funcName)?.[0];
+    }
+
+    /**
+     * Strips test code from Move source content.
+     * Removes: #[test_only] modules, #[test_only] declarations,
+     * and #[test] function declarations.
+     */
+    async stripTestCode(content: string): Promise<string> {
+        const service = TreeSitterService.getInstance();
+        const lang = await service.getLanguage(SupportedLanguage.Move);
+        const parser = await service.createParser(SupportedLanguage.Move);
+
+        const tree = parser.parse(content);
+        if (!tree) return content;
+
+        const rangesToRemove: Array<{ start: number; end: number }> = [];
+
+        // Build sets of matching attributes nodes
+        const testAttrQuery = new Query(lang, MoveAdapter.QUERIES.TEST_ATTR);
+        const testAttrs = new Set(
+            testAttrQuery.matches(tree.rootNode)
+                .map(m => m.captures.find(c => c.name === 'test-attrs')!.node.id)
+        );
+
+        const testOnlyAttrQuery = new Query(lang, MoveAdapter.QUERIES.TEST_ONLY_ATTR);
+        const testOnlyAttrs = new Set(
+            testOnlyAttrQuery.matches(tree.rootNode)
+                .map(m => m.captures.find(c => c.name === 'test-only-attrs')!.node.id)
+        );
+
+        // 1. Find #[test_only] modules (attributes is a sibling preceding the module)
+        for (const child of tree.rootNode.children) {
+            if (child.type === 'module') {
+                const prev = child.previousNamedSibling;
+                if (prev && prev.type === 'attributes' && testOnlyAttrs.has(prev.id)) {
+                    rangesToRemove.push({
+                        start: prev.startIndex,
+                        end: child.endIndex
+                    });
+                }
+            }
+        }
+
+        // 2. Find #[test] and #[test_only] declarations inside modules
+        const moduleQuery = new Query(lang, '(module) @module');
+        const moduleCaptures = moduleQuery.captures(tree.rootNode);
+
+        for (const capture of moduleCaptures) {
+            const moduleNode = capture.node;
+            // Skip modules already being removed
+            const moduleRemoved = rangesToRemove.some(
+                r => moduleNode.startIndex >= r.start && moduleNode.endIndex <= r.end
+            );
+            if (moduleRemoved) continue;
+
+            for (const child of moduleNode.children) {
+                if (child.type !== 'declaration') continue;
+
+                const attrs = child.children.find(c => c.type === 'attributes');
+                if (!attrs) continue;
+
+                if (testAttrs.has(attrs.id) || testOnlyAttrs.has(attrs.id)) {
+                    rangesToRemove.push({
+                        start: child.startIndex,
+                        end: child.endIndex
+                    });
+                }
+            }
+        }
+
+        if (rangesToRemove.length === 0) return content;
+
+        rangesToRemove.sort((a, b) => b.start - a.start);
+
+        let result = content;
+        for (const range of rangesToRemove) {
+            let end = range.end;
+            if (end < result.length && result[end] === '\n') end++;
+            result = result.substring(0, range.start) + result.substring(end);
+        }
+
+        return result;
+    }
+
+    override async calculateMetrics(files: FileContent[]): Promise<FileMetrics[]> {
+        const strippedFiles = await Promise.all(
+            files.map(async (file) => ({
+                path: file.path,
+                content: await this.stripTestCode(file.content)
+            }))
+        );
+        return super.calculateMetrics(strippedFiles);
+    }
+
+    override async calculateDiffMetrics(
+        file: FileContent,
+        addedLines: number[],
+        removedLines: number[],
+        status: 'added' | 'modified' | 'deleted'
+    ): Promise<DiffFileMetrics> {
+        if (status === 'deleted') {
+            return super.calculateDiffMetrics(file, addedLines, removedLines, status);
+        }
+
+        const strippedContent = await this.stripTestCode(file.content);
+        const originalLines = file.content.split('\n');
+        const strippedLines = strippedContent.split('\n');
+
+        const removedOriginalLines = new Set<number>();
+        let oi = 0, si = 0;
+        while (oi < originalLines.length && si < strippedLines.length) {
+            if (originalLines[oi] === strippedLines[si]) {
+                oi++;
+                si++;
+            } else {
+                removedOriginalLines.add(oi + 1);
+                oi++;
+            }
+        }
+        while (oi < originalLines.length) {
+            removedOriginalLines.add(oi + 1);
+            oi++;
+        }
+
+        const lineMapping = new Map<number, number>();
+        let strippedLineNum = 1;
+        for (let origLine = 1; origLine <= originalLines.length; origLine++) {
+            if (!removedOriginalLines.has(origLine)) {
+                lineMapping.set(origLine, strippedLineNum);
+                strippedLineNum++;
+            }
+        }
+
+        const filteredAddedLines: number[] = [];
+        for (const lineNum of addedLines) {
+            const mappedLine = lineMapping.get(lineNum);
+            if (mappedLine !== undefined) {
+                filteredAddedLines.push(mappedLine);
+            }
+        }
+
+        return super.calculateDiffMetrics(
+            { path: file.path, content: strippedContent },
+            filteredAddedLines,
+            removedLines,
+            status
+        );
     }
 
 }

--- a/src/languages/noirAdapter.ts
+++ b/src/languages/noirAdapter.ts
@@ -1,4 +1,4 @@
-import { FileContent, SupportedLanguage, GraphNode, GraphEdge, Visibility } from "../engine/types.js";
+import { FileContent, SupportedLanguage, GraphNode, GraphEdge, Visibility, FileMetrics, DiffFileMetrics } from "../engine/types.js";
 import { BaseAdapter } from "./baseAdapter.js";
 import { TreeSitterService } from "../util/treeSitter.js";
 import { Query, Node } from "web-tree-sitter";
@@ -8,7 +8,8 @@ export class NoirAdapter extends BaseAdapter {
     private static readonly QUERIES = {
         FUNCTIONS: `(function_item) @function`,
         SIMPLE_CALL: `(call_expression function: (identifier) @FUNC)`,
-        SCOPED_CALL: `(call_expression function: (scoped_identifier) @FUNC)`
+        SCOPED_CALL: `(call_expression function: (scoped_identifier) @FUNC)`,
+        ATTR_ITEM: `(attribute_item (content) @content) @attr`
     } as const;
 
     constructor() {
@@ -100,6 +101,145 @@ export class NoirAdapter extends BaseAdapter {
             }
         }
         return 'private';
+    }
+
+    /**
+     * Strips test code from Noir source content.
+     * Removes standalone #[test] functions (including #[test(should_fail)] etc.).
+     * Noir has no test module concept.
+     */
+    async stripTestCode(content: string): Promise<string> {
+        const service = TreeSitterService.getInstance();
+        const lang = await service.getLanguage(SupportedLanguage.Noir);
+        const parser = await service.createParser(SupportedLanguage.Noir);
+
+        const tree = parser.parse(content);
+        if (!tree) return content;
+
+        const rangesToRemove: Array<{ start: number; end: number }> = [];
+
+        // Noir's grammar stores attribute content as a flat text node.
+        // Match attribute_items whose content starts with "test".
+        const attrQuery = new Query(lang, NoirAdapter.QUERIES.ATTR_ITEM);
+        const testAttrs = new Set(
+            attrQuery.matches(tree.rootNode)
+                .filter(m => {
+                    const content = m.captures.find(c => c.name === 'content');
+                    return content && /^test\b/.test(content.node.text);
+                })
+                .map(m => m.captures.find(c => c.name === 'attr')!.node.id)
+        );
+
+        // Find #[test] functions
+        const fnQuery = new Query(lang, '(function_item) @fn');
+        const fnCaptures = fnQuery.captures(tree.rootNode);
+
+        for (const capture of fnCaptures) {
+            if (this.hasTestAttribute(capture.node, testAttrs)) {
+                const attrStart = this.getAttributeStart(capture.node);
+                rangesToRemove.push({
+                    start: attrStart,
+                    end: capture.node.endIndex
+                });
+            }
+        }
+
+        if (rangesToRemove.length === 0) return content;
+
+        rangesToRemove.sort((a, b) => b.start - a.start);
+
+        let result = content;
+        for (const range of rangesToRemove) {
+            let end = range.end;
+            if (end < result.length && result[end] === '\n') end++;
+            result = result.substring(0, range.start) + result.substring(end);
+        }
+
+        return result;
+    }
+
+    private hasTestAttribute(node: Node, testAttrIds: Set<number>): boolean {
+        let prev = node.previousNamedSibling;
+        while (prev && prev.type === 'attribute_item') {
+            if (testAttrIds.has(prev.id)) return true;
+            prev = prev.previousNamedSibling;
+        }
+        return false;
+    }
+
+    private getAttributeStart(node: Node): number {
+        let start = node.startIndex;
+        let prev = node.previousNamedSibling;
+        while (prev && prev.type === 'attribute_item') {
+            start = prev.startIndex;
+            prev = prev.previousNamedSibling;
+        }
+        return start;
+    }
+
+    override async calculateMetrics(files: FileContent[]): Promise<FileMetrics[]> {
+        const strippedFiles = await Promise.all(
+            files.map(async (file) => ({
+                path: file.path,
+                content: await this.stripTestCode(file.content)
+            }))
+        );
+        return super.calculateMetrics(strippedFiles);
+    }
+
+    override async calculateDiffMetrics(
+        file: FileContent,
+        addedLines: number[],
+        removedLines: number[],
+        status: 'added' | 'modified' | 'deleted'
+    ): Promise<DiffFileMetrics> {
+        if (status === 'deleted') {
+            return super.calculateDiffMetrics(file, addedLines, removedLines, status);
+        }
+
+        const strippedContent = await this.stripTestCode(file.content);
+        const originalLines = file.content.split('\n');
+        const strippedLines = strippedContent.split('\n');
+
+        const removedOriginalLines = new Set<number>();
+        let oi = 0, si = 0;
+        while (oi < originalLines.length && si < strippedLines.length) {
+            if (originalLines[oi] === strippedLines[si]) {
+                oi++;
+                si++;
+            } else {
+                removedOriginalLines.add(oi + 1);
+                oi++;
+            }
+        }
+        while (oi < originalLines.length) {
+            removedOriginalLines.add(oi + 1);
+            oi++;
+        }
+
+        const lineMapping = new Map<number, number>();
+        let strippedLineNum = 1;
+        for (let origLine = 1; origLine <= originalLines.length; origLine++) {
+            if (!removedOriginalLines.has(origLine)) {
+                lineMapping.set(origLine, strippedLineNum);
+                strippedLineNum++;
+            }
+        }
+
+        const filteredAddedLines: number[] = [];
+        for (const lineNum of addedLines) {
+            const mappedLine = lineMapping.get(lineNum);
+            if (mappedLine !== undefined) {
+                filteredAddedLines.push(mappedLine);
+            }
+        }
+
+        return super.calculateDiffMetrics(
+            { path: file.path, content: strippedContent },
+            filteredAddedLines,
+            removedLines,
+            status
+        );
     }
 
     protected override async identifyCalls(edges: GraphEdge[], files: FileContent[]) {

--- a/src/languages/rustAdapter.ts
+++ b/src/languages/rustAdapter.ts
@@ -26,6 +26,35 @@ export class RustAdapter extends BaseAdapter {
         `,
         GENERIC_SCOPED_CALL: `
             (call_expression function: (generic_function function: (scoped_identifier) @FUNC))
+        `,
+        TEST_ATTR: `
+            (attribute_item
+                (attribute
+                    (identifier) @attr-name
+                    (#eq? @attr-name "test")
+                )
+            ) @test-attr
+
+            (attribute_item
+                (attribute
+                    (scoped_identifier
+                        name: (identifier) @scoped-name
+                        (#eq? @scoped-name "test")
+                    )
+                )
+            ) @test-attr
+        `,
+        CFG_TEST_ATTR: `
+            (attribute_item
+                (attribute
+                    (identifier) @outer
+                    arguments: (token_tree
+                        (identifier) @inner
+                    )
+                    (#eq? @outer "cfg")
+                    (#eq? @inner "test")
+                )
+            ) @cfg-test-attr
         `
     } as const;
 
@@ -362,12 +391,25 @@ export class RustAdapter extends BaseAdapter {
         // Collect byte ranges to remove (startIndex, endIndex)
         const rangesToRemove: Array<{ start: number; end: number }> = [];
 
+        // Build sets of attribute_item nodes matching #[cfg(test)] and #[test]
+        const cfgTestQuery = new Query(lang, RustAdapter.QUERIES.CFG_TEST_ATTR);
+        const cfgTestAttrs = new Set(
+            cfgTestQuery.matches(tree.rootNode)
+                .map(m => m.captures.find(c => c.name === 'cfg-test-attr')!.node.id)
+        );
+
+        const testAttrQuery = new Query(lang, RustAdapter.QUERIES.TEST_ATTR);
+        const testAttrs = new Set(
+            testAttrQuery.matches(tree.rootNode)
+                .map(m => m.captures.find(c => c.name === 'test-attr')!.node.id)
+        );
+
         // 1. Find #[cfg(test)] mod blocks
         const modQuery = new Query(lang, '(mod_item) @mod');
         const modCaptures = modQuery.captures(tree.rootNode);
 
         for (const capture of modCaptures) {
-            if (this.hasCfgTestAttribute(capture.node)) {
+            if (this.hasAttributeFromSet(capture.node, cfgTestAttrs)) {
                 const attrStart = this.getAttributeStart(capture.node);
                 rangesToRemove.push({
                     start: attrStart,
@@ -381,7 +423,7 @@ export class RustAdapter extends BaseAdapter {
         const fnCaptures = fnQuery.captures(tree.rootNode);
 
         for (const capture of fnCaptures) {
-            if (this.hasTestAttribute(capture.node)) {
+            if (this.hasAttributeFromSet(capture.node, testAttrs)) {
                 // Skip if already inside a range being removed
                 const alreadyCovered = rangesToRemove.some(
                     r => capture.node.startIndex >= r.start && capture.node.endIndex <= r.end
@@ -413,34 +455,19 @@ export class RustAdapter extends BaseAdapter {
         return result;
     }
 
-    private hasCfgTestAttribute(node: Node): boolean {
-        // Look for attribute_item siblings or children that contain cfg(test)
-        // In tree-sitter-rust, attributes are children of the item
+    /**
+     * Checks whether a node has an associated attribute_item (child or preceding sibling)
+     * whose node ID is in the provided set of matched attribute IDs.
+     */
+    private hasAttributeFromSet(node: Node, attrIds: Set<number>): boolean {
         for (const child of node.children) {
-            if (child.type === 'attribute_item') {
-                const text = child.text;
-                if (/^#\[cfg\(\s*test\s*\)\]$/.test(text)) return true;
-            }
-        }
-        // Also check previous siblings (outer attributes)
-        let prev = node.previousNamedSibling;
-        while (prev && prev.type === 'attribute_item') {
-            if (/^#\[cfg\(\s*test\s*\)\]$/.test(prev.text)) return true;
-            prev = prev.previousNamedSibling;
-        }
-        return false;
-    }
-
-    private hasTestAttribute(node: Node): boolean {
-        for (const child of node.children) {
-            if (child.type === 'attribute_item') {
-                const text = child.text;
-                if (/^#\[test\]$/.test(text)) return true;
+            if (child.type === 'attribute_item' && attrIds.has(child.id)) {
+                return true;
             }
         }
         let prev = node.previousNamedSibling;
         while (prev && prev.type === 'attribute_item') {
-            if (/^#\[test\]$/.test(prev.text)) return true;
+            if (attrIds.has(prev.id)) return true;
             prev = prev.previousNamedSibling;
         }
         return false;

--- a/src/languages/rustAdapter.ts
+++ b/src/languages/rustAdapter.ts
@@ -1,4 +1,4 @@
-import { FileContent, SupportedLanguage, GraphNode, GraphEdge, Visibility } from "../engine/types.js";
+import { FileContent, SupportedLanguage, GraphNode, GraphEdge, Visibility, FileMetrics, DiffFileMetrics } from "../engine/types.js";
 import { BaseAdapter } from "./baseAdapter.js";
 import { TreeSitterService } from "../util/treeSitter.js";
 import { Query, Node } from "web-tree-sitter";
@@ -345,4 +345,194 @@ export class RustAdapter extends BaseAdapter {
         return this.symbolsByLabel.get(callText)?.[0];
     }
 
+    /**
+     * Strips test code from Rust source content.
+     * Removes: #[cfg(test)] module blocks, #[test] standalone functions,
+     * and their associated attribute lines.
+     * Does NOT strip doc-test code blocks inside /// comments.
+     */
+    async stripTestCode(content: string): Promise<string> {
+        const service = TreeSitterService.getInstance();
+        const lang = await service.getLanguage(SupportedLanguage.Rust);
+        const parser = await service.createParser(SupportedLanguage.Rust);
+
+        const tree = parser.parse(content);
+        if (!tree) return content;
+
+        // Collect byte ranges to remove (startIndex, endIndex)
+        const rangesToRemove: Array<{ start: number; end: number }> = [];
+
+        // 1. Find #[cfg(test)] mod blocks
+        const modQuery = new Query(lang, '(mod_item) @mod');
+        const modCaptures = modQuery.captures(tree.rootNode);
+
+        for (const capture of modCaptures) {
+            if (this.hasCfgTestAttribute(capture.node)) {
+                const attrStart = this.getAttributeStart(capture.node);
+                rangesToRemove.push({
+                    start: attrStart,
+                    end: capture.node.endIndex
+                });
+            }
+        }
+
+        // 2. Find #[test] standalone functions (not already inside a #[cfg(test)] module)
+        const fnQuery = new Query(lang, '(function_item) @fn');
+        const fnCaptures = fnQuery.captures(tree.rootNode);
+
+        for (const capture of fnCaptures) {
+            if (this.hasTestAttribute(capture.node)) {
+                // Skip if already inside a range being removed
+                const alreadyCovered = rangesToRemove.some(
+                    r => capture.node.startIndex >= r.start && capture.node.endIndex <= r.end
+                );
+                if (!alreadyCovered) {
+                    const attrStart = this.getAttributeStart(capture.node);
+                    rangesToRemove.push({
+                        start: attrStart,
+                        end: capture.node.endIndex
+                    });
+                }
+            }
+        }
+
+        if (rangesToRemove.length === 0) return content;
+
+        // Sort ranges by start position (descending) to remove from end first
+        rangesToRemove.sort((a, b) => b.start - a.start);
+
+        let result = content;
+        for (const range of rangesToRemove) {
+            // Extend range to include the trailing newline if present
+            let end = range.end;
+            if (end < result.length && result[end] === '\n') end++;
+
+            result = result.substring(0, range.start) + result.substring(end);
+        }
+
+        return result;
+    }
+
+    private hasCfgTestAttribute(node: Node): boolean {
+        // Look for attribute_item siblings or children that contain cfg(test)
+        // In tree-sitter-rust, attributes are children of the item
+        for (const child of node.children) {
+            if (child.type === 'attribute_item') {
+                const text = child.text;
+                if (/^#\[cfg\(\s*test\s*\)\]$/.test(text)) return true;
+            }
+        }
+        // Also check previous siblings (outer attributes)
+        let prev = node.previousNamedSibling;
+        while (prev && prev.type === 'attribute_item') {
+            if (/^#\[cfg\(\s*test\s*\)\]$/.test(prev.text)) return true;
+            prev = prev.previousNamedSibling;
+        }
+        return false;
+    }
+
+    private hasTestAttribute(node: Node): boolean {
+        for (const child of node.children) {
+            if (child.type === 'attribute_item') {
+                const text = child.text;
+                if (/^#\[test\]$/.test(text)) return true;
+            }
+        }
+        let prev = node.previousNamedSibling;
+        while (prev && prev.type === 'attribute_item') {
+            if (/^#\[test\]$/.test(prev.text)) return true;
+            prev = prev.previousNamedSibling;
+        }
+        return false;
+    }
+
+    private getAttributeStart(node: Node): number {
+        // Include preceding attribute lines (e.g., #[cfg(test)], #[test])
+        let start = node.startIndex;
+        let prev = node.previousNamedSibling;
+        while (prev && prev.type === 'attribute_item') {
+            start = prev.startIndex;
+            prev = prev.previousNamedSibling;
+        }
+        // Also include attributes that are children of the node itself
+        for (const child of node.children) {
+            if (child.type === 'attribute_item' && child.startIndex < start) {
+                start = child.startIndex;
+            }
+        }
+        return start;
+    }
+
+    override async calculateMetrics(files: FileContent[]): Promise<FileMetrics[]> {
+        const strippedFiles = await Promise.all(
+            files.map(async (file) => ({
+                path: file.path,
+                content: await this.stripTestCode(file.content)
+            }))
+        );
+        return super.calculateMetrics(strippedFiles);
+    }
+
+    override async calculateDiffMetrics(
+        file: FileContent,
+        addedLines: number[],
+        removedLines: number[],
+        status: 'added' | 'modified' | 'deleted'
+    ): Promise<DiffFileMetrics> {
+        if (status === 'deleted') {
+            return super.calculateDiffMetrics(file, addedLines, removedLines, status);
+        }
+
+        const strippedContent = await this.stripTestCode(file.content);
+        const originalLines = file.content.split('\n');
+        const strippedLines = strippedContent.split('\n');
+
+        // Build mapping from original line numbers to stripped line numbers
+        // by finding which original lines were removed
+        const removedOriginalLines = new Set<number>();
+        let oi = 0, si = 0;
+
+        // Use a diff approach: walk both line arrays
+        // Lines that exist in original but not in stripped were removed
+        while (oi < originalLines.length && si < strippedLines.length) {
+            if (originalLines[oi] === strippedLines[si]) {
+                oi++;
+                si++;
+            } else {
+                removedOriginalLines.add(oi + 1); // 1-indexed
+                oi++;
+            }
+        }
+        // Remaining original lines were all removed
+        while (oi < originalLines.length) {
+            removedOriginalLines.add(oi + 1);
+            oi++;
+        }
+
+        // Filter out added lines that fall in stripped test regions
+        const filteredAddedLines: number[] = [];
+        // Build line number mapping: original -> stripped
+        const lineMapping = new Map<number, number>();
+        let strippedLineNum = 1;
+        for (let origLine = 1; origLine <= originalLines.length; origLine++) {
+            if (!removedOriginalLines.has(origLine)) {
+                lineMapping.set(origLine, strippedLineNum);
+                strippedLineNum++;
+            }
+        }
+
+        for (const lineNum of addedLines) {
+            const mappedLine = lineMapping.get(lineNum);
+            if (mappedLine !== undefined) {
+                filteredAddedLines.push(mappedLine);
+            }
+        }
+
+        return super.calculateDiffMetrics(
+            { path: file.path, content: strippedContent },
+            filteredAddedLines,
+            removedLines,
+            status
+        );
+    }
 }

--- a/tests/languages/cairo/stripTests.test.ts
+++ b/tests/languages/cairo/stripTests.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import { CairoAdapter } from '../../../src/languages/cairoAdapter.js';
+
+describe('CairoAdapter Test Stripping', () => {
+    const adapter = new CairoAdapter();
+
+    describe('stripTestCode', () => {
+        it('should strip #[cfg(test)] mod blocks', async () => {
+            const content = `fn production() -> u32 {
+    42
+}
+
+#[cfg(test)]
+mod tests {
+    use super::production;
+
+    #[test]
+    fn test_production() {
+        assert(production() == 42, 'fail');
+    }
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('fn production()');
+            expect(stripped).not.toContain('mod tests');
+            expect(stripped).not.toContain('#[cfg(test)]');
+            expect(stripped).not.toContain('test_production');
+        });
+
+        it('should strip standalone #[test] functions', async () => {
+            const content = `fn helper() -> u32 {
+    1
+}
+
+#[test]
+fn test_helper() {
+    assert(helper() == 1, 'fail');
+}
+
+fn another_helper() -> u32 {
+    2
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('fn helper()');
+            expect(stripped).toContain('fn another_helper()');
+            expect(stripped).not.toContain('test_helper');
+            expect(stripped).not.toContain('#[test]');
+        });
+
+        it('should strip #[test] functions with extra attributes', async () => {
+            const content = `fn production() -> u32 { 42 }
+
+#[test]
+#[available_gas(2000000)]
+fn test_with_gas() {
+    assert(1 == 1, 'ok');
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('fn production()');
+            expect(stripped).not.toContain('test_with_gas');
+            expect(stripped).not.toContain('#[test]');
+            expect(stripped).not.toContain('#[available_gas');
+        });
+
+        it('should return content unchanged when no tests present', async () => {
+            const content = `fn greet() -> felt252 {
+    'hello'
+}
+
+fn main() {
+    greet();
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toBe(content);
+        });
+    });
+
+    describe('calculateMetrics with test stripping', () => {
+        it('should exclude #[cfg(test)] mod from metrics', async () => {
+            const contentWithTests = `fn production() -> u32 {
+    if true {
+        42
+    } else {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::production;
+
+    #[test]
+    fn test_production() {
+        assert(production() == 42, 'fail');
+    }
+
+    #[test]
+    fn test_edge() {
+        if production() > 0 {
+            assert(true, 'ok');
+        }
+    }
+}
+`;
+
+            const contentWithoutTests = `fn production() -> u32 {
+    if true {
+        42
+    } else {
+        0
+    }
+}
+`;
+
+            const [metricsWith] = await adapter.calculateMetrics([
+                { path: 'with_tests.cairo', content: contentWithTests }
+            ]);
+            const [metricsWithout] = await adapter.calculateMetrics([
+                { path: 'without_tests.cairo', content: contentWithoutTests }
+            ]);
+
+            expect(metricsWith.nloc).toBe(metricsWithout.nloc);
+            expect(metricsWith.cognitiveComplexity).toBe(metricsWithout.cognitiveComplexity);
+        });
+
+        it('should strip standalone #[test] functions from metrics', async () => {
+            const withTest = `fn real_fn() -> u32 {
+    1
+}
+
+#[test]
+fn test_real_fn() {
+    assert(real_fn() == 1, 'fail');
+}
+`;
+            const withoutTest = `fn real_fn() -> u32 {
+    1
+}
+`;
+
+            const [metricsWith] = await adapter.calculateMetrics([
+                { path: 'a.cairo', content: withTest }
+            ]);
+            const [metricsWithout] = await adapter.calculateMetrics([
+                { path: 'b.cairo', content: withoutTest }
+            ]);
+
+            expect(metricsWith.nloc).toBe(metricsWithout.nloc);
+        });
+    });
+});

--- a/tests/languages/move/stripTests.test.ts
+++ b/tests/languages/move/stripTests.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import { MoveAdapter } from '../../../src/languages/moveAdapter.js';
+
+describe('MoveAdapter Test Stripping', () => {
+    const adapter = new MoveAdapter();
+
+    describe('stripTestCode', () => {
+        it('should strip #[test_only] modules', async () => {
+            const content = `module 0x1::main {
+    fun production(): u64 {
+        42
+    }
+}
+
+#[test_only]
+module 0x1::test_helpers {
+    fun helper(): u64 { 1 }
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('module 0x1::main');
+            expect(stripped).toContain('fun production()');
+            expect(stripped).not.toContain('test_helpers');
+            expect(stripped).not.toContain('#[test_only]');
+        });
+
+        it('should strip #[test] function declarations', async () => {
+            const content = `module 0x1::my_module {
+    fun production(): u64 {
+        42
+    }
+
+    #[test]
+    fun test_production() {
+        assert!(production() == 42, 0);
+    }
+
+    fun another(): u64 {
+        1
+    }
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('fun production()');
+            expect(stripped).toContain('fun another()');
+            expect(stripped).not.toContain('test_production');
+            expect(stripped).not.toContain('#[test]');
+        });
+
+        it('should strip #[test_only] function declarations', async () => {
+            const content = `module 0x1::my_module {
+    fun production(): u64 { 42 }
+
+    #[test_only]
+    fun test_helper(): u64 { 1 }
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('fun production()');
+            expect(stripped).not.toContain('test_helper');
+            expect(stripped).not.toContain('#[test_only]');
+        });
+
+        it('should strip #[test] with #[expected_failure]', async () => {
+            const content = `module 0x1::my_module {
+    fun production(): u64 { 42 }
+
+    #[test]
+    #[expected_failure(abort_code = 0)]
+    fun test_fails() {
+        abort 0
+    }
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('fun production()');
+            expect(stripped).not.toContain('test_fails');
+            expect(stripped).not.toContain('#[expected_failure');
+        });
+
+        it('should strip #[test] with signer arguments', async () => {
+            const content = `module 0x1::my_module {
+    fun production(): u64 { 42 }
+
+    #[test(a = @0x1)]
+    fun test_with_signer(a: signer) {
+    }
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('fun production()');
+            expect(stripped).not.toContain('test_with_signer');
+        });
+
+        it('should return content unchanged when no tests present', async () => {
+            const content = `module 0x1::my_module {
+    fun production(): u64 {
+        42
+    }
+
+    public fun get(): u64 {
+        production()
+    }
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toBe(content);
+        });
+    });
+
+    describe('calculateMetrics with test stripping', () => {
+        it('should exclude test code from metrics', async () => {
+            const contentWithTests = `module 0x1::my_module {
+    fun production(): u64 {
+        if (true) {
+            42
+        } else {
+            0
+        }
+    }
+
+    #[test]
+    fun test_production() {
+        assert!(production() == 42, 0);
+    }
+
+    #[test_only]
+    fun test_helper(): u64 {
+        if (true) { 1 } else { 0 }
+    }
+}
+`;
+
+            const contentWithoutTests = `module 0x1::my_module {
+    fun production(): u64 {
+        if (true) {
+            42
+        } else {
+            0
+        }
+    }
+}
+`;
+
+            const [metricsWith] = await adapter.calculateMetrics([
+                { path: 'with_tests.move', content: contentWithTests }
+            ]);
+            const [metricsWithout] = await adapter.calculateMetrics([
+                { path: 'without_tests.move', content: contentWithoutTests }
+            ]);
+
+            expect(metricsWith.nloc).toBe(metricsWithout.nloc);
+            expect(metricsWith.cognitiveComplexity).toBe(metricsWithout.cognitiveComplexity);
+        });
+    });
+});

--- a/tests/languages/noir/stripTests.test.ts
+++ b/tests/languages/noir/stripTests.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { NoirAdapter } from '../../../src/languages/noirAdapter.js';
+
+describe('NoirAdapter Test Stripping', () => {
+    const adapter = new NoirAdapter();
+
+    describe('stripTestCode', () => {
+        it('should strip #[test] functions', async () => {
+            const content = `fn production() -> u32 {
+    42
+}
+
+#[test]
+fn test_production() {
+    assert(production() == 42);
+}
+
+fn another() -> u32 {
+    1
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('fn production()');
+            expect(stripped).toContain('fn another()');
+            expect(stripped).not.toContain('test_production');
+            expect(stripped).not.toContain('#[test]');
+        });
+
+        it('should strip #[test(should_fail)] functions', async () => {
+            const content = `fn production() -> u32 { 42 }
+
+#[test(should_fail)]
+fn test_should_fail() {
+    assert(1 == 2);
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('fn production()');
+            expect(stripped).not.toContain('test_should_fail');
+            expect(stripped).not.toContain('#[test(should_fail)]');
+        });
+
+        it('should strip #[test(should_fail_with = "msg")] functions', async () => {
+            const content = `fn production() -> u32 { 42 }
+
+#[test(should_fail_with = "not equal")]
+fn test_fail_msg() {
+    assert(1 == 2);
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('fn production()');
+            expect(stripped).not.toContain('test_fail_msg');
+            expect(stripped).not.toContain('should_fail_with');
+        });
+
+        it('should not strip functions without test attributes', async () => {
+            const content = `fn test_helper() -> u32 { 1 }
+
+fn run_tests() {
+    test_helper();
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('fn test_helper()');
+            expect(stripped).toContain('fn run_tests()');
+        });
+
+        it('should return content unchanged when no tests present', async () => {
+            const content = `fn greet() -> Field {
+    42
+}
+
+fn main() {
+    let x = greet();
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toBe(content);
+        });
+    });
+
+    describe('calculateMetrics with test stripping', () => {
+        it('should exclude test code from metrics', async () => {
+            const contentWithTests = `fn production() -> u32 {
+    if true {
+        42
+    } else {
+        0
+    }
+}
+
+#[test]
+fn test_production() {
+    assert(production() == 42);
+}
+
+#[test(should_fail)]
+fn test_fail() {
+    assert(1 == 2);
+}
+`;
+
+            const contentWithoutTests = `fn production() -> u32 {
+    if true {
+        42
+    } else {
+        0
+    }
+}
+`;
+
+            const [metricsWith] = await adapter.calculateMetrics([
+                { path: 'with_tests.nr', content: contentWithTests }
+            ]);
+            const [metricsWithout] = await adapter.calculateMetrics([
+                { path: 'without_tests.nr', content: contentWithoutTests }
+            ]);
+
+            expect(metricsWith.nloc).toBe(metricsWithout.nloc);
+            expect(metricsWith.cognitiveComplexity).toBe(metricsWithout.cognitiveComplexity);
+        });
+    });
+});

--- a/tests/languages/rust/stripTests.test.ts
+++ b/tests/languages/rust/stripTests.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import { RustAdapter } from '../../../src/languages/rustAdapter.js';
+import { FileContent } from '../../../src/engine/types.js';
+
+describe('RustAdapter Test Stripping', () => {
+    const adapter = new RustAdapter();
+
+    describe('stripTestCode', () => {
+        it('should strip #[cfg(test)] mod blocks', async () => {
+            const content = `use std::collections::HashMap;
+
+fn production_code() -> i32 {
+    42
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_production_code() {
+        assert_eq!(production_code(), 42);
+    }
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('fn production_code()');
+            expect(stripped).toContain('use std::collections::HashMap');
+            expect(stripped).not.toContain('mod tests');
+            expect(stripped).not.toContain('#[cfg(test)]');
+            expect(stripped).not.toContain('test_production_code');
+        });
+
+        it('should strip standalone #[test] functions', async () => {
+            const content = `fn helper() -> i32 {
+    1
+}
+
+#[test]
+fn test_helper() {
+    assert_eq!(helper(), 1);
+}
+
+fn another_helper() -> i32 {
+    2
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('fn helper()');
+            expect(stripped).toContain('fn another_helper()');
+            expect(stripped).not.toContain('test_helper');
+            expect(stripped).not.toContain('#[test]');
+        });
+
+        it('should NOT strip doc-test code blocks inside /// comments', async () => {
+            const content = `/// Adds two numbers together.
+///
+/// # Examples
+///
+/// \`\`\`
+/// let result = add(2, 3);
+/// assert_eq!(result, 5);
+/// \`\`\`
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('/// ```');
+            expect(stripped).toContain('/// let result = add(2, 3);');
+            expect(stripped).toContain('/// assert_eq!(result, 5);');
+            expect(stripped).toContain('pub fn add(a: i32, b: i32) -> i32');
+        });
+
+        it('should return content unchanged when no tests present', async () => {
+            const content = `use std::io;
+
+pub fn greet(name: &str) -> String {
+    format!("Hello, {}!", name)
+}
+
+fn main() {
+    println!("{}", greet("world"));
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toBe(content);
+        });
+    });
+
+    describe('calculateMetrics with test stripping', () => {
+        it('should exclude #[cfg(test)] mod from metrics', async () => {
+            const contentWithTests = `fn production() -> i32 {
+    if true {
+        42
+    } else {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_production() {
+        assert_eq!(production(), 42);
+    }
+
+    #[test]
+    fn test_production_edge() {
+        let x = production();
+        if x > 0 {
+            assert!(true);
+        }
+    }
+}
+`;
+
+            const contentWithoutTests = `fn production() -> i32 {
+    if true {
+        42
+    } else {
+        0
+    }
+}
+`;
+
+            const [metricsWithTests] = await adapter.calculateMetrics([
+                { path: 'with_tests.rs', content: contentWithTests }
+            ]);
+            const [metricsWithoutTests] = await adapter.calculateMetrics([
+                { path: 'without_tests.rs', content: contentWithoutTests }
+            ]);
+
+            // The metrics should be very close since test code is stripped
+            expect(metricsWithTests.nloc).toBe(metricsWithoutTests.nloc);
+            expect(metricsWithTests.cognitiveComplexity).toBe(metricsWithoutTests.cognitiveComplexity);
+            expect(metricsWithTests.estimatedHours).toBe(metricsWithoutTests.estimatedHours);
+        });
+
+        it('should not affect metrics when doc-tests are present', async () => {
+            const content: FileContent = {
+                path: 'documented.rs',
+                content: `/// Adds two numbers.
+///
+/// # Examples
+///
+/// \`\`\`
+/// let result = add(2, 3);
+/// assert_eq!(result, 5);
+/// \`\`\`
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+`
+            };
+
+            const metrics = await adapter.calculateMetrics([content]);
+            expect(metrics).toHaveLength(1);
+            // Doc comments should still be counted
+            expect(metrics[0].linesWithComments).toBeGreaterThan(0);
+            expect(metrics[0].nloc).toBeGreaterThan(0);
+        });
+
+        it('should strip standalone #[test] functions from metrics', async () => {
+            const withTest = `fn real_fn() -> i32 {
+    1
+}
+
+#[test]
+fn test_real_fn() {
+    assert_eq!(real_fn(), 1);
+}
+`;
+            const withoutTest = `fn real_fn() -> i32 {
+    1
+}
+`;
+
+            const [metricsWith] = await adapter.calculateMetrics([
+                { path: 'a.rs', content: withTest }
+            ]);
+            const [metricsWithout] = await adapter.calculateMetrics([
+                { path: 'b.rs', content: withoutTest }
+            ]);
+
+            expect(metricsWith.nloc).toBe(metricsWithout.nloc);
+        });
+    });
+});

--- a/tests/languages/rust/stripTests.test.ts
+++ b/tests/languages/rust/stripTests.test.ts
@@ -86,6 +86,92 @@ fn main() {
             const stripped = await adapter.stripTestCode(content);
             expect(stripped).toBe(content);
         });
+
+        it('should strip #[tokio::test] functions (scoped test attribute)', async () => {
+            const content = `fn production() -> i32 { 42 }
+
+#[tokio::test]
+async fn async_test() {
+    assert_eq!(production(), 42);
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('fn production()');
+            expect(stripped).not.toContain('async_test');
+            expect(stripped).not.toContain('#[tokio::test]');
+        });
+
+        it('should strip scoped test attributes with arguments', async () => {
+            const content = `fn production() -> i32 { 42 }
+
+#[tokio1::test(crate = "tokio1")]
+async fn async_test() {
+    assert_eq!(production(), 42);
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('fn production()');
+            expect(stripped).not.toContain('async_test');
+            expect(stripped).not.toContain('tokio1::test');
+        });
+
+        it('should strip scoped test with non-test cfg attribute', async () => {
+            const content = `fn production() -> i32 { 42 }
+
+#[cfg(tokio_unstable)]
+#[tokio::test(flavor = "current_thread", unhandled_panic = "shutdown_runtime")]
+async fn async_test() {
+    assert_eq!(production(), 42);
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('fn production()');
+            expect(stripped).not.toContain('async_test');
+            expect(stripped).not.toContain('#[tokio::test');
+            expect(stripped).not.toContain('#[cfg(tokio_unstable)]');
+        });
+
+        it('should not strip functions with test-like names but no #[test] attribute', async () => {
+            const content = `fn test_helper() -> i32 { 1 }
+
+fn run_tests() {
+    test_helper();
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('fn test_helper()');
+            expect(stripped).toContain('fn run_tests()');
+        });
+
+        it('should strip #[test] functions with multiple attributes', async () => {
+            const content = `fn production() -> i32 { 42 }
+
+#[test]
+#[should_panic]
+fn test_panics() {
+    panic!("expected");
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('fn production()');
+            expect(stripped).not.toContain('test_panics');
+            expect(stripped).not.toContain('#[test]');
+            expect(stripped).not.toContain('#[should_panic]');
+        });
+
+        it('should handle #[cfg(test)] with extra whitespace in source', async () => {
+            const content = `fn production() -> i32 { 42 }
+
+#[cfg( test )]
+mod tests {
+    fn test_it() {}
+}
+`;
+            const stripped = await adapter.stripTestCode(content);
+            expect(stripped).toContain('fn production()');
+            expect(stripped).not.toContain('mod tests');
+            expect(stripped).not.toContain('test_it');
+        });
     });
 
     describe('calculateMetrics with test stripping', () => {


### PR DESCRIPTION
#### Proposed Changes for #3 

Add a `stripTestCode` method to `RustAdapter` that removes test code from source content before metrics are calculated. Override `calculateMetrics` and `calculateDiffMetrics` to strip first, then delegate to the base adapter.

#### Stripping Rules

- Module blocks: Remove any module annotated with `#[cfg(test)]`, including the full module body
- Standalone functions: Remove any function annotated with `#[test]`, regardless of location
- Attributes: Remove the `#[cfg(test)]` and `#[test]` attribute lines themselves
- Doc-tests: Do NOT strip code blocks inside `///` comments. These are documentation, not test code

#### TODO

- [x] Rust: Native `#[test]` functions and `#[cfg(test)]` modules.
- [x] Cairo: Inherits Rust’s `#[test]` and `#[cfg(test)]` syntax.
- [x] Move: Uses `#[test]` and `#[test_only]` attributes inside modules.
- [x] Noir: Uses the `#[test]` attribute for inline circuit testing.